### PR TITLE
Hit SIGSEGV because of the increased Difficulty.

### DIFF
--- a/libdevcore/CommonData.cpp
+++ b/libdevcore/CommonData.cpp
@@ -176,14 +176,14 @@ std::string dev::getScaledSize(double _value, double _divisor, int _precision, s
 
 std::string dev::getFormattedHashes(double _hr, ScaleSuffix _suffix, int _precision)
 {
-    static string suffixes[] = {"h", "Kh", "Mh", "Gh"};
-    return dev::getScaledSize(_hr, 1000.0, _precision, suffixes, 4, _suffix);
+    static string suffixes[] = {"h", "Kh", "Mh", "Gh", "Th", "Ph"};
+    return dev::getScaledSize(_hr, 1000.0, _precision, suffixes, 6, _suffix);
 }
 
 std::string dev::getFormattedMemory(double _mem, ScaleSuffix _suffix, int _precision)
 {
-    static string suffixes[] = {"B", "KB", "MB", "GB"};
-    return dev::getScaledSize(_mem, 1024.0, _precision, suffixes, 4, _suffix);
+    static string suffixes[] = {"B", "KB", "MB", "GB", "TB", "PB"};
+    return dev::getScaledSize(_mem, 1024.0, _precision, suffixes, 6, _suffix);
 }
 
 std::string dev::padLeft(std::string _value, size_t _length, char _fillChar) 


### PR DESCRIPTION
**Describe the bug**

Hit SIGSEGV because of the increased Difficulty. The issue is reproed in Linux environment only for now.

**To Reproduce**
Steps to reproduce the behavior:

Run ethminer  --cuda --pool http://localhost:8080

On Windows, it does not crash, but prints the following string.
 i 15:12:31 <unknown> Epoch : 422 Difficulty : 386.91 

On CentOS with gcc-9, it crashes with SIGSEGV. Attached the stdout messages.
[1.txt](https://github.com/etclabscore/ethminer/files/6447047/1.txt)



**Expected behavior**
The SIGSEGV should not happen, but show Th unit when printing out the difficulty.

**Environment (please complete the following information):**
- CentOS 7, gcc-9, cuda 11.3
- Ethminer Version 0.18.0, 0.19.0, main
- Ethminer options used: --cuda  --pool http://localhost:8080

**Additional context**
The fix is as follows. Reproed in gdb env and it was tested that the code fixes the issue.

```
diff --git a/libdevcore/CommonData.cpp b/libdevcore/CommonData.cpp
index 7dae6fccb..6c5d4d50d 100644
--- a/libdevcore/CommonData.cpp
+++ b/libdevcore/CommonData.cpp
@@ -176,13 +176,13 @@ std::string dev::getScaledSize(double _value, double _divisor, int _precision, s

 std::string dev::getFormattedHashes(double _hr, ScaleSuffix _suffix, int _precision)
 {
-    static string suffixes[] = {"h", "Kh", "Mh", "Gh"};
+    static string suffixes[] = {"h", "Kh", "Mh", "Gh", "Th", "Ph"};
     return dev::getScaledSize(_hr, 1000.0, _precision, suffixes, 6, _suffix);
 }

 std::string dev::getFormattedMemory(double _mem, ScaleSuffix _suffix, int _precision)
 {
-    static string suffixes[] = {"B", "KB", "MB", "GB"};
+    static string suffixes[] = {"B", "KB", "MB", "GB", "TB", "PB"};
     return dev::getScaledSize(_mem, 1024.0, _precision, suffixes, 6, _suffix);
 }
```